### PR TITLE
Fix incorrect trade routing to raydium

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
   "makefile.configureOnOpen": false,
   "python.testing.pytestArgs": [
-    "tests"
+    "tests",
+    "-s"
   ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,

--- a/app/trading/trading/executor.py
+++ b/app/trading/trading/executor.py
@@ -1,5 +1,6 @@
 from solana.rpc.async_api import AsyncClient
 from solbot_cache.launch import LaunchCache
+from solbot_cache.rayidum import get_preferred_pool
 from solbot_common.config import settings
 from solbot_common.constants import PUMP_FUN_PROGRAM, RAY_V4
 from solbot_common.log import logger
@@ -9,7 +10,6 @@ from solbot_db.session import NEW_ASYNC_SESSION, provide_session
 from solders.keypair import Keypair  # type: ignore
 from solders.signature import Signature  # type: ignore
 from sqlmodel import select
-
 from trading.swap import SwapDirection, SwapInType
 from trading.transaction import TradingRoute, TradingService
 
@@ -30,6 +30,64 @@ class TradingExecutor:
         if not private_key:
             raise ValueError("Wallet not found")
         return Keypair.from_bytes(private_key)
+    
+    def _get_direction_address(self, swap_event: SwapEvent) -> tuple[SwapDirection, str]:
+        """ Extract the direction and address from the swap event """
+        if swap_event.swap_mode == "ExactIn":
+            return SwapDirection.Buy, swap_event.output_mint
+        elif swap_event.swap_mode == "ExactOut":
+            return SwapDirection.Sell, swap_event.input_mint
+        else:
+            raise ValueError("swap_mode must be ExactIn or ExactOut")
+
+    async def find_route(self, swap_event: SwapEvent) -> TradingRoute:
+        """ Find the best route for executing the swap event """
+        # Check if you need to use it Pump Transactions with contract
+        should_use_pump = False
+        program_id = swap_event.program_id
+        
+        _, token_address = self._get_direction_address(swap_event)
+
+        try:
+            is_pump_token_launched = await self._launch_cache.is_pump_token_launched(token_address)
+            logger.info(f"Pump token {token_address} is launched: {is_pump_token_launched}")
+            if program_id == PUMP_FUN_PROGRAM_ID or (
+                token_address.endswith("pump") and not is_pump_token_launched
+            ):
+                should_use_pump = True
+                logger.info(
+                    f"Token {token_address} has not launched, using Pump protocol to trade"
+                )
+            else:
+                # Check if the token is launched on Raydium
+                pool_data = await get_preferred_pool(token_address)
+                if pool_data is not None:
+                    logger.info(
+                        f"Token {token_address} is launched on Raydium, using Raydium protocol to trade"
+                    )
+                    # Program ID should be Raydium V4 when the token is launched on Raydium
+                    if program_id != RAY_V4_PROGRAM_ID:
+                        logger.warning("Original transaction was on a different protocol than Raydium")
+                    # assert program_id == RAY_V4_PROGRAM_ID, "Program ID must be Raydium V4"
+                    # 如果 token 在 Raydium 上启动，则使用 Raydium 协议进行交易
+                    #swap_event.program_id = RAY_V4_PROGRAM_ID
+        except Exception as e:
+            logger.exception(f"Failed to check launch status, cause: {e}")
+
+        if should_use_pump:
+            logger.info("Program ID is PUMP")
+            trade_route = TradingRoute.PUMP
+        # NOTE: Testing is not very ideal, use alternatives for the time being
+        elif swap_event.program_id == RAY_V4_PROGRAM_ID:
+            logger.info("Program ID is RayV4")
+            trade_route = TradingRoute.RAYDIUM_V4
+        elif program_id is None:
+            logger.warning("Program ID is Unknown. Using Jupiter DEX aggregator to trade")
+            trade_route = TradingRoute.DEX
+        else:
+            raise ValueError(f"Program ID is not supported, {swap_event.program_id}")
+
+        return trade_route
 
     async def exec(self, swap_event: SwapEvent) -> Signature | None:
         """执行交易
@@ -46,53 +104,49 @@ class TradingExecutor:
         else:
             raise ValueError("slippage_bps must be specified")
 
-        if swap_event.swap_mode == "ExactIn":
-            swap_direction = SwapDirection.Buy
-            token_address = swap_event.output_mint
-        elif swap_event.swap_mode == "ExactOut":
-            swap_direction = SwapDirection.Sell
-            token_address = swap_event.input_mint
-        else:
-            raise ValueError("swap_mode must be ExactIn or ExactOut")
+        swap_direction, token_address = self._get_direction_address(swap_event)
 
         sig = None
         keypair = await self.__get_keypair(swap_event.user_pubkey)
         swap_in_type = SwapInType(swap_event.swap_in_type)
 
-        # 检查是否需要使用 Pump 协议进行交易
-        should_use_pump = False
-        program_id = swap_event.program_id
+        if False:
+            # 检查是否需要使用 Pump 协议进行交易
+            should_use_pump = False
+            program_id = swap_event.program_id
 
-        try:
-            is_pump_token_launched = await self._launch_cache.is_pump_token_launched(token_address)
-            if program_id == PUMP_FUN_PROGRAM_ID or (
-                token_address.endswith("pump") and not is_pump_token_launched
-            ):
-                should_use_pump = True
-                logger.info(
-                    f"Token {token_address} is not launched on Raydium, using Pump protocol to trade"
-                )
+            try:
+                is_pump_token_launched = await self._launch_cache.is_pump_token_launched(token_address)
+                if program_id == PUMP_FUN_PROGRAM_ID or (
+                    token_address.endswith("pump") and not is_pump_token_launched
+                ):
+                    should_use_pump = True
+                    logger.info(
+                        f"Token {token_address} is not launched on Raydium, using Pump protocol to trade"
+                    )
+                else:
+                    logger.info(
+                        f"Token {token_address} is launched on Raydium, using Raydium protocol to trade"
+                    )
+                    # 如果 token 在 Raydium 上启动，则使用 Raydium 协议进行交易
+                    swap_event.program_id = RAY_V4_PROGRAM_ID
+            except Exception as e:
+                logger.exception(f"Failed to check launch status, cause: {e}")
+
+            if should_use_pump:
+                logger.info("Program ID is PUMP")
+                trade_route = TradingRoute.PUMP
+            # NOTE: 测试下来不是很理想，暂时使用备选方案
+            elif swap_event.program_id == RAY_V4_PROGRAM_ID:
+                logger.info("Program ID is RayV4")
+                trade_route = TradingRoute.RAYDIUM_V4
+            elif program_id is None:
+                logger.warning("Program ID is Unknown, So We use thrid party to trade")
+                trade_route = TradingRoute.DEX
             else:
-                logger.info(
-                    f"Token {token_address} is launched on Raydium, using Raydium protocol to trade"
-                )
-                # 如果 token 在 Raydium 上启动，则使用 Raydium 协议进行交易
-                swap_event.program_id = RAY_V4_PROGRAM_ID
-        except Exception as e:
-            logger.exception(f"Failed to check launch status, cause: {e}")
-
-        if should_use_pump:
-            logger.info("Program ID is PUMP")
-            trade_route = TradingRoute.PUMP
-        # NOTE: 测试下来不是很理想，暂时使用备选方案
-        elif swap_event.program_id == RAY_V4_PROGRAM_ID:
-            logger.info("Program ID is RayV4")
-            trade_route = TradingRoute.RAYDIUM_V4
-        elif program_id is None:
-            logger.warning("Program ID is Unknown, So We use thrid party to trade")
-            trade_route = TradingRoute.DEX
+                raise ValueError(f"Program ID is not supported, {swap_event.program_id}")
         else:
-            raise ValueError(f"Program ID is not supported, {swap_event.program_id}")
+            trade_route = await self.find_route(swap_event)
 
         sig = await self._trading_service.use_route(trade_route).swap(
             keypair,

--- a/libs/common/solbot_common/constants.py
+++ b/libs/common/solbot_common/constants.py
@@ -30,4 +30,5 @@ PUMP_SELL_METHOD = 12502976635542562355
 SWAP_PROGRAMS = [
     "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8",  # Raydium Liquidity Pool V4
     "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P",  # Pump
+    "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG",  # MMeteora DAMM v2
 ]

--- a/tests/cache/test_rayv4.py
+++ b/tests/cache/test_rayv4.py
@@ -1,9 +1,23 @@
 import pytest
-from solbot_cache.rayidum import get_preferred_pool
+from solbot_cache.rayidum import get_pool_data_from_rpc, get_preferred_pool
 
 
 @pytest.mark.asyncio
 async def test_get_preferred_pool():
     token_mint = "2ru87k7yAZnDRsnqVpgJYETFgqVApuBcwB2xDb19pump"
     pool = await get_preferred_pool(token_mint)
+    print(pool)
     assert pool is not None
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("token_mint", [
+    "2ru87k7yAZnDRsnqVpgJYETFgqVApuBcwB2xDb19pump",
+    # "B5r8sv2EsxHj9orqVah3UxGkMjkL4CZNrz8PCvyUpump",
+    "6Q7GpNCtARwQSZtaWn3yuadPfteYzGxvP5Gqeswtpump",
+    # "7i5KKsX2weiTkry7jA4ZwSuXGhs5eJBEjY8vVxR4mRx",
+    # "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+])
+async def test_get_pool_data_from_rpc(token_mint):
+    pool_data = await get_pool_data_from_rpc(token_mint)
+    print(pool_data)
+    assert pool_data is not None

--- a/tests/trading/transaction/test_trading_service.py
+++ b/tests/trading/transaction/test_trading_service.py
@@ -10,7 +10,8 @@ from trading.transaction.builders.base import TransactionBuilder
 from trading.transaction.builders.gmgn import GMGNTransactionBuilder
 from trading.transaction.builders.pump import PumpTransactionBuilder
 from trading.transaction.builders.ray_v4 import RaydiumV4TransactionBuilder
-from trading.transaction.factory import AggregateTransactionBuilder, TradingService
+from trading.transaction.factory import (AggregateTransactionBuilder,
+                                         TradingService)
 from trading.transaction.protocol import TradingRoute
 
 
@@ -48,10 +49,10 @@ class MockBuilder(TransactionBuilder):
 
 @pytest.mark.asyncio
 async def test_aggregate_builder_returns_fastest_success():
-    """测试聚合构建器返回最快成功的结果"""
+    """Testing the aggregation builder returns the fastest successful results"""
     mock_client = AsyncMock(spec=AsyncClient)
 
-    # 创建三个模拟构建器,延迟不同
+    # Create three mock builders with different delays
     fast_builder = MockBuilder(mock_client, delay=0.1)
     slow_builder = MockBuilder(mock_client, delay=0.3)
     failing_builder = MockBuilder(mock_client, delay=0.2, should_fail=True)
@@ -60,16 +61,16 @@ async def test_aggregate_builder_returns_fastest_success():
         mock_client, [fast_builder, slow_builder, failing_builder]
     )
 
-    # 执行构建
+    # Execute the build
     result = await aggregate_builder.build_swap_transaction(
         keypair=MagicMock(),
         token_address="mock_token",
         ui_amount=1.0,
-        swap_direction=SwapDirection.BUY,
+        swap_direction=SwapDirection.Buy,
         slippage_bps=100,
     )
 
-    # 验证结果
+    # Verify the result
     assert isinstance(result, VersionedTransaction)
     assert fast_builder.build_called
     assert slow_builder.build_called
@@ -95,7 +96,7 @@ async def test_aggregate_builder_handles_all_failures():
             keypair=MagicMock(),
             token_address="mock_token",
             ui_amount=1.0,
-            swap_direction=SwapDirection.BUY,
+            swap_direction=SwapDirection.Buy,
             slippage_bps=100,
         )
 
@@ -111,16 +112,16 @@ async def test_trading_service_route_selection():
     service = TradingService(mock_client)
 
     # 测试 PUMP 路由
-    builder = await service.select_builder(TradingRoute.PUMP)
+    builder = service.select_builder(TradingRoute.PUMP)
     assert isinstance(builder, PumpTransactionBuilder)
 
     # 测试 RAYDIUM_V4 路由
-    builder = await service.select_builder(TradingRoute.RAYDIUM_V4)
+    builder = service.select_builder(TradingRoute.RAYDIUM_V4)
     assert isinstance(builder, RaydiumV4TransactionBuilder)
 
     # 测试无效路由
     with pytest.raises(ValueError) as exc_info:
-        await service.select_builder("INVALID_ROUTE")
+        service.select_builder("INVALID_ROUTE")
     assert "Unsupported trading route" in str(exc_info.value)
 
 
@@ -137,9 +138,10 @@ async def test_trading_service_use_route():
         service = TradingService(mock_client)
 
         # 测试 GMGN 路由
-        swapper = service.use_route(TradingRoute.GMGN)
-        assert isinstance(swapper.builder, GMGNTransactionBuilder)
-        mock_gmgn_sender.assert_called_once()
+        # NOTE: GMGN is not an enumerated trading route
+        # swapper = service.use_route(TradingRoute.GMGN)
+        # assert isinstance(swapper.builder, GMGNTransactionBuilder)
+        # mock_gmgn_sender.assert_called_once()
 
         # 测试带 Jito 的普通路由
         swapper = service.use_route(TradingRoute.PUMP, use_jito=True)
@@ -149,4 +151,9 @@ async def test_trading_service_use_route():
         # 测试默认路由
         swapper = service.use_route(TradingRoute.RAYDIUM_V4)
         assert isinstance(swapper.builder, RaydiumV4TransactionBuilder)
+        mock_default_sender.assert_called_once()
+        
+        # DEX
+        swapper = service.use_route(TradingRoute.DEX)
+        assert isinstance(swapper.builder, AggregateTransactionBuilder)
         mock_default_sender.assert_called_once()


### PR DESCRIPTION
The trading executor was assuming that if a pump token was launched then it is in a raydium pool, and then the code was trying to execute the swap on raydium.

However, if the token launched on Meteora for example, then the transaction would fail attempting to find the pool on raydium.

This fix does the following, when the pump token has been launched. 

1) Check if it is has a pool on raydium and trade there if it does, or

2) If not, then fall back to the Jupiter DEX.

This should fix issue #70 