### PR TITLE
Use free jupiter api

### DIFF
--- a/libs/common/solbot_common/utils/jupiter.py
+++ b/libs/common/solbot_common/utils/jupiter.py
@@ -2,10 +2,14 @@ from typing import Literal
 
 import httpx
 
+#TODO: Set this up in the config
+# api.jup.ag in not free anymore
+JUPITER_API_URL = "https://lite-api.jup.ag"
+
 
 class JupiterAPI:
     def __init__(self):
-        self.client = httpx.AsyncClient(base_url="https://api.jup.ag")
+        self.client = httpx.AsyncClient(base_url=JUPITER_API_URL)
 
     async def get_quote(
         self,

--- a/tests/trading/conftest.py
+++ b/tests/trading/conftest.py
@@ -1,12 +1,11 @@
-from types import SimpleNamespace
-
 import pytest
+import pytest_asyncio
 from solbot_common.types.swap import SwapEvent
 from solbot_common.types.tx import TxEvent, TxType
 from solbot_common.utils import get_async_client
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def rpc_client():
     """Real Async Solana RPC client shared across trading tests."""
     client = get_async_client()
@@ -33,6 +32,12 @@ def executor(rpc_client):
 #decimals=9, to_amount=4181819987502, to_decimals=6, mint='8qAbzjWBxD2kxnNwE9voR9Xkr2zT8mg1aM6ri34Jpump', who='DfMxre4cKmvogbLrPigxmibVTTQDuzjdXojWzjCXXhzj', tx_type=<TxType.ADD_POSITION: 'add_position'>, tx_direction='buy', timestamp=17564489
 #61, pre_token_amount=25274744460671, post_token_amount=29456564448173, program_id='6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P')
 
+#SwapEvent #2
+#user_pubkey='5b9tuvErmHAXpfGNv4wyRDQx6mLhYp4tKry52gxhToBa' swap_mode='ExactIn' input_mint='So1111111111111111111111111111
+#1111111111112' output_mint='6NqXBdXA38ZXEGU7nGfp9Fr4JSTKgtfZDqZit91Dbonk' amount=50000000 ui_amount=0.05 timestamp=1756531032 amount_pct=None swap_in_type='qty' priority_fee=0.0001 slippage_bps=250 by='copytrade' dynamic_slippage=False min_sl
+#ippage_bps=None max_slippage_bps=None program_id=None tx_event=TxEvent(signature='3gqWLDzno5LKU1asduxDdACMbQmQFdvfwU6WJarnWT3Mcrwb73oYbmfaFaDVLFtyZhwToWi4WZEawL9y9JzdP1RA', from_amount=1090005000, from_decimals=9, to_amount=1037510604527, to_
+#decimals=6, mint='6NqXBdXA38ZXEGU7nGfp9Fr4JSTKgtfZDqZit91Dbonk', who='DfMxre4cKmvogbLrPigxmibVTTQDuzjdXojWzjCXXhzj', tx_type=<TxType.ADD_POSITION: 'add_position'>, tx_direction='buy', timestamp=1756531032, pre_token_amount=19836071332282, pos
+#t_token_amount=20873581936809, program_id=None)
 
 @pytest.fixture
 def tx_event_from_logs() -> TxEvent:
@@ -82,20 +87,46 @@ def swap_event_from_logs(tx_event_from_logs) -> SwapEvent:
 
 
 @pytest.fixture
-def swap_event_from_logs_second():
-    """DEX-aggregator style event (no specific program id)."""
-    return SimpleNamespace(
+def tx_event_from_logs_second() -> TxEvent:
+    """Second TxEvent instance derived from logged example (#2)."""
+    return TxEvent(
+        signature="3gqWLDzno5LKU1asduxDdACMbQmQFdvfwU6WJarnWT3Mcrwb73oYbmfaFaDVLFtyZhwToWi4WZEawL9y9JzdP1RA",
+        from_amount=1090005000,
+        from_decimals=9,
+        to_amount=1037510604527,
+        to_decimals=6,
+        mint="6NqXBdXA38ZXEGU7nGfp9Fr4JSTKgtfZDqZit91Dbonk",
+        who="DfMxre4cKmvogbLrPigxmibVTTQDuzjdXojWzjCXXhzj",
+        tx_type=TxType.ADD_POSITION,
+        tx_direction="buy",
+        timestamp=1756531032,
+        pre_token_amount=19836071332282,
+        post_token_amount=20873581936809,
+        program_id=None,
+    )
+
+
+@pytest.fixture
+def swap_event_from_logs_second(tx_event_from_logs_second) -> SwapEvent:
+    """Second SwapEvent matching the commented example (#2)."""
+    return SwapEvent(
+        user_pubkey="5b9tuvErmHAXpfGNv4wyRDQx6mLhYp4tKry52gxhToBa",
         swap_mode="ExactIn",
         input_mint="So11111111111111111111111111111111111111112",
-        output_mint="G1WcqfZxkZGHvPLRvbSpVDgzsWxuWxbi1GcufwcHpump",
+        output_mint="6NqXBdXA38ZXEGU7nGfp9Fr4JSTKgtfZDqZit91Dbonk",
+        amount=50000000,
+        ui_amount=0.05,
+        timestamp=1756531032,
+        amount_pct=None,
+        swap_in_type="qty",
+        priority_fee=0.0001,
+        slippage_bps=250,
+        by="copytrade",
+        dynamic_slippage=False,
+        min_slippage_bps=None,
+        max_slippage_bps=None,
         program_id=None,
-        user_pubkey="HyygEkpVJJpuUyUYdAWQTZMwX4Ee1BS9ND7Yd2YdkWQg",
-        ui_amount=0.0001,
-        slippage_bps=100,
-        swap_in_type="Pct",
-        priority_fee=None,
-        amount=1000,
-        timestamp=0,
+        tx_event=tx_event_from_logs_second,
     )
 
 

--- a/tests/trading/test_executor.py
+++ b/tests/trading/test_executor.py
@@ -1,0 +1,10 @@
+""" Test TradingExecutor class. This uses actual RPC client (and connects to the network)"""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_exec(executor, swap_event_from_logs_second):
+    sig = await executor.exec(swap_event_from_logs_second)
+    assert sig is not None
+


### PR DESCRIPTION
The jupiter endpoint `https://api.jup.ag` is now paid. 

The free endpoint is now lite-api.jup.ag